### PR TITLE
Fix bug where lessons can be created for guardians

### DIFF
--- a/src/main/java/tutorease/address/logic/commands/AddLessonCommand.java
+++ b/src/main/java/tutorease/address/logic/commands/AddLessonCommand.java
@@ -32,8 +32,9 @@ public class AddLessonCommand extends LessonCommand {
             + PREFIX_START_DATE + dateTimeNowString() + " "
             + PREFIX_DURATION + "1\n";
 
-    public static final String MESSAGE_SUCCESS = "New lesson added: %1$s";
-    public static final String MESSAGE_OVERLAP_LESSON = "This lesson overlaps with another lesson";
+    public static final String MESSAGE_SUCCESS = "New lesson added: %1$s.";
+    public static final String MESSAGE_OVERLAP_LESSON = "This lesson overlaps with another lesson.";
+    public static final String MESSAGE_INVALID_ROLE = "Lessons can only be added to students.";
     public static final String TO_STRING_FORMAT = "AddLessonCommand[studentId=%s,"
             + " fee=%s, startDateTime=%s, endDateTime=%s]";
 
@@ -62,17 +63,33 @@ public class AddLessonCommand extends LessonCommand {
         requireNonNull(model);
         ObservableList<Person> personList = model.getFilteredPersonList();
 
-        if (studentId.getValue() > personList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-        }
+        validateStudentId(personList);
         Person student = personList.get(studentId.getValue());
+        validateStudentRole(student);
         Lesson lesson = new Lesson(student, fee, this.startDateTime, this.endDateTime);
-        if (model.hasLessons(lesson)) {
-            throw new CommandException(MESSAGE_OVERLAP_LESSON);
-        }
+        validateModelHasLesson(model.hasLessons(lesson));
         model.addLesson(lesson);
         return new CommandResult(String.format(MESSAGE_SUCCESS, lesson));
     }
+
+    private static void validateModelHasLesson(boolean model) throws CommandException {
+        if (model) {
+            throw new CommandException(AddLessonCommand.MESSAGE_OVERLAP_LESSON);
+        }
+    }
+
+    private static void validateStudentRole(Person student) throws CommandException {
+        if (!student.isStudent()) {
+            throw new CommandException(MESSAGE_INVALID_ROLE);
+        }
+    }
+
+    private void validateStudentId(ObservableList<Person> personList) throws CommandException {
+        if (studentId.getValue() > personList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/main/java/tutorease/address/model/person/Guardian.java
+++ b/src/main/java/tutorease/address/model/person/Guardian.java
@@ -25,4 +25,14 @@ public class Guardian extends Person {
     public Role getRole() {
         return new Role(Role.GUARDIAN);
     }
+
+    @Override
+    public boolean isGuardian() {
+        return true;
+    }
+
+    @Override
+    public boolean isStudent() {
+        return false;
+    }
 }

--- a/src/main/java/tutorease/address/model/person/Person.java
+++ b/src/main/java/tutorease/address/model/person/Person.java
@@ -60,6 +60,8 @@ public abstract class Person {
     }
 
     public abstract Role getRole();
+    public abstract boolean isGuardian();
+    public abstract boolean isStudent();
 
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}

--- a/src/main/java/tutorease/address/model/person/Student.java
+++ b/src/main/java/tutorease/address/model/person/Student.java
@@ -28,4 +28,15 @@ public class Student extends Person {
     public Role getRole() {
         return new Role(STUDENT);
     }
+
+    @Override
+    public boolean isGuardian() {
+        return false;
+    }
+
+    @Override
+    public boolean isStudent() {
+        return true;
+    }
+
 }

--- a/src/test/java/tutorease/address/logic/commands/AddLessonCommandTest.java
+++ b/src/test/java/tutorease/address/logic/commands/AddLessonCommandTest.java
@@ -25,6 +25,7 @@ import tutorease.address.model.TutorEase;
 import tutorease.address.model.lesson.Lesson;
 import tutorease.address.model.lesson.StudentId;
 import tutorease.address.model.person.Person;
+import tutorease.address.testutil.GuardianBuilder;
 import tutorease.address.testutil.LessonBuilder;
 import tutorease.address.testutil.StudentBuilder;
 
@@ -39,6 +40,33 @@ public class AddLessonCommandTest {
 
         assertThrows(CommandException.class, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, ()
             -> addLessonCommand.execute(modelStub));
+    }
+    @Test
+    public void execute_guardian_throwsCommandException() throws ParseException {
+        ModelStub modelStub = new ModelStubAcceptingLessonAdded();
+        modelStub.addPerson(new GuardianBuilder().build());
+        StudentId studentId = new StudentId("1");
+        Lesson lesson = new LessonBuilder().build();
+        AddLessonCommand addLessonCommand = new AddLessonCommand(studentId, lesson.getFee(),
+                lesson.getStartDateTime(), lesson.getEndDateTime());
+
+        assertThrows(CommandException.class, AddLessonCommand.MESSAGE_INVALID_ROLE, ()
+            -> addLessonCommand.execute(modelStub));
+    }
+    @Test
+    public void execute_studentAcceptedByModel_addSuccessful() throws Exception {
+        ModelStubAcceptingLessonAdded modelStub = new ModelStubAcceptingLessonAdded();
+        modelStub.addPerson(new StudentBuilder().build());
+        Lesson validLesson = new LessonBuilder().build();
+        StudentId studentId = new StudentId("1");
+        AddLessonCommand addLessonCommand = new AddLessonCommand(studentId, validLesson.getFee(),
+                validLesson.getStartDateTime(), validLesson.getEndDateTime());
+
+        CommandResult commandResult = addLessonCommand.execute(modelStub);
+
+        assertEquals(String.format(AddLessonCommand.MESSAGE_SUCCESS, validLesson),
+                commandResult.getFeedbackToUser());
+        assertEquals(validLesson, modelStub.lessonsAdded.get(0));
     }
     @Test
     public void execute_lessonAcceptedByModel_addSuccessful() throws Exception {

--- a/src/test/java/tutorease/address/model/person/GuardianTest.java
+++ b/src/test/java/tutorease/address/model/person/GuardianTest.java
@@ -16,6 +16,7 @@ import static tutorease.address.logic.commands.CommandTestUtil.VALID_TAG_SUPPORT
 import static tutorease.address.testutil.Assert.assertThrows;
 import static tutorease.address.testutil.TypicalGuardians.CHICK;
 import static tutorease.address.testutil.TypicalGuardians.MEG;
+import static tutorease.address.testutil.TypicalStudents.ALICE;
 
 import org.junit.jupiter.api.Test;
 
@@ -100,5 +101,21 @@ public class GuardianTest {
                 + ", email=" + MEG.getEmail() + ", address=" + MEG.getAddress() + ", tags=" + MEG.getTags()
                 + ", role=" + MEG.getRole() + "}";
         assertEquals(expected, MEG.toString());
+    }
+    @Test
+    public void guardianIsGuardian() {
+        assertTrue(MEG.isGuardian());
+    }
+    @Test
+    public void guardianIsNotStudent() {
+        assertFalse(MEG.isStudent());
+    }
+    @Test
+    public void studentIsStudent() {
+        assertTrue(ALICE.isStudent());
+    }
+    @Test
+    public void studentIsNotGuardian() {
+        assertFalse(ALICE.isGuardian());
     }
 }


### PR DESCRIPTION
An error will now be thrown when a user attempts to create a lesson for a guardian.
![image](https://github.com/user-attachments/assets/1dd6ca9d-c183-4960-9fe8-f49b1cbccea1)
